### PR TITLE
fix: riktig id for Airflow-bruker

### DIFF
--- a/docker/airflow/Dockerfile
+++ b/docker/airflow/Dockerfile
@@ -1,6 +1,6 @@
 FROM apache/airflow:2.7.3-python3.10
 LABEL org.opencontainers.image.source https://github.com/navikt/vdl-airflow
-USER airflow
+USER ${AIRFLOW_UID}
 
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt \


### PR DESCRIPTION
Nada har skrudd av muligheten til å kjøre med root-tilgang, vi må da bruke Airflow-brukeren.